### PR TITLE
Fix PHP deprecation when passing null to json_decode

### DIFF
--- a/src/DiscussionAndPostAttributes.php
+++ b/src/DiscussionAndPostAttributes.php
@@ -49,7 +49,7 @@ class DiscussionAndPostAttributes
 
     protected function avatarUrl(AbstractModel $model): ?string
     {
-        $avatarRules = json_decode($this->settings->get('anonymous-posting.formulaireAvatars'), true);
+        $avatarRules = json_decode((string)$this->settings->get('anonymous-posting.formulaireAvatars'), true);
 
         // Check if the setting has a value first to avoid degrading performance by retrieving a useless relationship
         // Also skip if Formulaire is not installed to avoid 500 error that would block access to the forum


### PR DESCRIPTION
The problem recurs in the PHP8+ environment. Problem occurs when passing null into the json_decode function.